### PR TITLE
Create single MQTT connection for all publish actions

### DIFF
--- a/solarman/__init__.py
+++ b/solarman/__init__.py
@@ -81,7 +81,7 @@ def single_run(file):
             _t,
             inverter_device_state,
         )
-        mqtt_connection = Mqtt(config["mqtt"]);
+        mqtt_connection = Mqtt(config["mqtt"])
         for i in station_data:
             if station_data[i] and i not in discard:
                 mqtt_connection.message(topic + "/station/" + i, station_data[i])
@@ -108,7 +108,9 @@ def single_run(file):
             topic + "/inverter/deviceState",
             inverter_data["deviceState"],
         )
-        mqtt_connection.message(topic + "/logger/deviceState", logger_data["deviceState"])
+        mqtt_connection.message(
+            topic + "/logger/deviceState", logger_data["deviceState"]
+        )
         logging.info(
             "%s - Inverter DeviceState: %s"
             "-> Only status MQTT publish (probably offline due to nighttime shutdown)",

--- a/solarman/__init__.py
+++ b/solarman/__init__.py
@@ -81,36 +81,34 @@ def single_run(file):
             _t,
             inverter_device_state,
         )
+        mqtt_connection = Mqtt(config["mqtt"]);
         for i in station_data:
             if station_data[i] and i not in discard:
-                Mqtt(config["mqtt"], topic + "/station/" + i, station_data[i])
+                mqtt_connection.message(topic + "/station/" + i, station_data[i])
 
         for i in inverter_data:
             if inverter_data[i] and i not in discard:
-                Mqtt(config["mqtt"], topic + "/inverter/" + i, inverter_data[i])
+                mqtt_connection.message(topic + "/inverter/" + i, inverter_data[i])
         if inverter_data_list:
-            Mqtt(
-                config["mqtt"],
+            mqtt_connection.message(
                 topic + "/inverter/attributes",
                 json.dumps(inverter_data_list),
             )
 
         for i in logger_data:
             if logger_data[i] and i not in discard:
-                Mqtt(config["mqtt"], topic + "/logger/" + i, logger_data[i])
+                mqtt_connection.message(topic + "/logger/" + i, logger_data[i])
         if logger_data_list:
-            Mqtt(
-                config["mqtt"],
+            mqtt_connection.message(
                 topic + "/logger/attributes",
                 json.dumps(logger_data_list),
             )
     else:
-        Mqtt(
-            config["mqtt"],
+        mqtt_connection.message(
             topic + "/inverter/deviceState",
             inverter_data["deviceState"],
         )
-        Mqtt(config["mqtt"], topic + "/logger/deviceState", logger_data["deviceState"])
+        mqtt_connection.message(topic + "/logger/deviceState", logger_data["deviceState"])
         logging.info(
             "%s - Inverter DeviceState: %s"
             "-> Only status MQTT publish (probably offline due to nighttime shutdown)",

--- a/solarman/mqtt.py
+++ b/solarman/mqtt.py
@@ -14,17 +14,15 @@ class Mqtt:
     MQTT connect and publish
     """
 
-    def __init__(self, config, topic, msg):
+    def __init__(self, config):
         """
-        MQTT Connect and send
+        MQTT Connect
         """
         self.broker = config["broker"]
         self.port = config["port"]
         self.username = config["username"]
         self.password = config["password"]
-        self.topic = topic
-        self.msg = msg
-        Mqtt.message(self)
+        self.client = Mqtt.connect(self)
 
     def connect(self):
         """
@@ -37,7 +35,7 @@ class Mqtt:
         client.connect(self.broker, self.port)
         return client
 
-    def publish(self, client):
+    def publish(self, client, topic, msg):
         """
         Publish a message on a MQTT topic
         :param client: Connect parameters
@@ -45,17 +43,16 @@ class Mqtt:
         :param msg: Message payload
         :return:
         """
-        result = client.publish(self.topic, self.msg)
+        result = client.publish(topic, msg)
         # result: [0, 1]
         status = result[0]
         if status == 0:
-            logging.debug("Send %s to %s", self.msg, self.topic)
+            logging.debug("Send %s to %s", msg, topic)
         else:
-            logging.error("Failed to send message to topic %s", self.topic)
+            logging.error("Failed to send message to topic %s", topic)
 
-    def message(self):
+    def message(self, topic, msg):
         """
-        MQTT Connect and send
+        MQTT Send message to selected topic
         """
-        client = Mqtt.connect(self)
-        Mqtt.publish(self, client)
+        Mqtt.publish(self, self.client, topic, msg)


### PR DESCRIPTION
In my case multiply connection was not properly publishing all topics but only random ones (without any error, just some of topics ware not populated on MQTT Broker side).

Screen from debug log (messages was cut by me)
![image](https://user-images.githubusercontent.com/18705953/183836432-283027eb-3303-4d9a-a8e5-51df16359330.png)
View from MQTT Explorer after restarting solarman-mqtt docker container:
![image](https://user-images.githubusercontent.com/18705953/183836565-ec7b922f-ac90-4189-9f79-b8dee0120fc5.png)

After changing to single connection every time there is a publish list of all topics is correctly reported in MQTT Explorer (and further in other MQTT clients as well).
Using VerneMQ.

I'm not python programmer so feel free to do any necessary changes.